### PR TITLE
feat: implement user creation in orchestrator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
       "devDependencies": {
         "@commitlint/cli": "^19.3.0",
         "@commitlint/config-conventional": "^19.2.2",
+        "@faker-js/faker": "9.7.0",
         "@types/babel__core": "^7.20.5",
         "@types/babel__generator": "^7.27.0",
         "@types/babel__template": "^7.4.4",
@@ -956,6 +957,23 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.7.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.7.0.tgz",
+      "integrity": "sha512-aozo5vqjCmDoXLNUJarFZx2IN/GgGaogY4TMJ6so/WLZOWpSV7fvj2dmrV6sEAnUm1O7aCrhTibjpzeDFgNqbg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.2.2",
+    "@faker-js/faker": "9.7.0",
     "@types/babel__core": "^7.20.5",
     "@types/babel__generator": "^7.27.0",
     "@types/babel__template": "^7.4.4",

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -10,77 +10,57 @@ beforeAll(async () => {
 describe("GET /api/v1/users/[username]", () => {
   describe("Anonymous user", () => {
     test("With exact case match", async () => {
-      const response1 = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "MesmoCase",
-          email: "mesmo.case@eduarte.dev",
-          password: "senha123",
-        }),
+      const createdUser = await orchestrator.createUser({
+        username: "MesmoCase",
       });
 
-      expect(response1.status).toBe(201);
-
-      const response2 = await fetch(
+      const response = await fetch(
         "http://localhost:3000/api/v1/users/MesmoCase",
       );
 
-      expect(response2.status).toBe(200);
+      expect(response.status).toBe(200);
 
-      const response2Body = await response2.json();
+      const responseBody = await response.json();
 
-      expect(response2Body).toEqual({
-        id: response2Body.id,
+      expect(responseBody).toEqual({
+        id: responseBody.id,
         username: "MesmoCase",
-        email: "mesmo.case@eduarte.dev",
-        password: response2Body.password,
-        created_at: response2Body.created_at,
-        updated_at: response2Body.updated_at,
+        email: createdUser.email,
+        password: responseBody.password,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
       });
 
-      expect(uuidVersion(response2Body.id)).toBe(4);
-      expect(Date.parse(response2Body.created_at)).not.toBeNaN();
-      expect(Date.parse(response2Body.updated_at)).not.toBeNaN();
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
-    test("With exact case mismatch", async () => {
-      const response1 = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "CaseDiferente",
-          email: "case.diferente@eduarte.dev",
-          password: "senha123",
-        }),
+    test("With case mismatch", async () => {
+      const createdUser = await orchestrator.createUser({
+        username: "CaseDiferente",
       });
 
-      expect(response1.status).toBe(201);
-
-      const response2 = await fetch(
+      const response = await fetch(
         "http://localhost:3000/api/v1/users/casediferente",
       );
 
-      expect(response2.status).toBe(200);
+      expect(response.status).toBe(200);
 
-      const response2Body = await response2.json();
+      const responseBody = await response.json();
 
-      expect(response2Body).toEqual({
-        id: response2Body.id,
+      expect(responseBody).toEqual({
+        id: responseBody.id,
         username: "CaseDiferente",
-        email: "case.diferente@eduarte.dev",
-        password: response2Body.password,
-        created_at: response2Body.created_at,
-        updated_at: response2Body.updated_at,
+        email: createdUser.email,
+        password: responseBody.password,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
       });
 
-      expect(uuidVersion(response2Body.id)).toBe(4);
-      expect(Date.parse(response2Body.created_at)).not.toBeNaN();
-      expect(Date.parse(response2Body.updated_at)).not.toBeNaN();
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
     });
 
     test("With nonexistent username", async () => {
@@ -90,9 +70,9 @@ describe("GET /api/v1/users/[username]", () => {
 
       expect(response.status).toBe(404);
 
-      const response2Body = await response.json();
+      const responseBody = await response.json();
 
-      expect(response2Body).toEqual({
+      expect(responseBody).toEqual({
         name: "NotFoundError",
         message: "O username informado não foi encontrado no sistema.",
         action: "Verifique se o username está digitado corretamente.",

--- a/tests/integration/api/v1/users/[username]/patch.test.js
+++ b/tests/integration/api/v1/users/[username]/patch.test.js
@@ -18,40 +18,28 @@ describe("PATCH /api/v1/users/[username]", () => {
           method: "PATCH",
         },
       );
+
       expect(response.status).toBe(404);
-      const response2Body = await response.json();
-      expect(response2Body).toEqual({
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
         name: "NotFoundError",
         message: "O username informado não foi encontrado no sistema.",
         action: "Verifique se o username está digitado corretamente.",
         status_code: 404,
       });
     });
+
     test("With duplicated 'username'", async () => {
-      const user1Response = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "user1",
-          email: "user1@eduarte.dev",
-          password: "senha123",
-        }),
+      await orchestrator.createUser({
+        username: "user1",
       });
-      expect(user1Response.status).toBe(201);
-      const user2Response = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "user2",
-          email: "user2@eduarte.dev",
-          password: "senha123",
-        }),
+
+      await orchestrator.createUser({
+        username: "user2",
       });
-      expect(user2Response.status).toBe(201);
+
       const response = await fetch("http://localhost:3000/api/v1/users/user2", {
         method: "PATCH",
         headers: {
@@ -61,8 +49,11 @@ describe("PATCH /api/v1/users/[username]", () => {
           username: "user1",
         }),
       });
+
       expect(response.status).toBe(400);
+
       const responseBody = await response.json();
+
       expect(responseBody).toEqual({
         name: "ValidationError",
         message: "O username informado já está sendo utilizado.",
@@ -70,33 +61,18 @@ describe("PATCH /api/v1/users/[username]", () => {
         status_code: 400,
       });
     });
+
     test("With duplicated 'email'", async () => {
-      const user1Response = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "email1",
-          email: "email1@eduarte.dev",
-          password: "senha123",
-        }),
+      await orchestrator.createUser({
+        email: "email1@eduarte.dev",
       });
-      expect(user1Response.status).toBe(201);
-      const user2Response = await fetch("http://localhost:3000/api/v1/users", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          username: "email2",
-          email: "email2@eduarte.dev",
-          password: "senha123",
-        }),
+
+      const createdUser2 = await orchestrator.createUser({
+        email: "email2@eduarte.dev",
       });
-      expect(user2Response.status).toBe(201);
+
       const response = await fetch(
-        "http://localhost:3000/api/v1/users/email2",
+        `http://localhost:3000/api/v1/users/${createdUser2.username}`,
         {
           method: "PATCH",
           headers: {
@@ -107,8 +83,11 @@ describe("PATCH /api/v1/users/[username]", () => {
           }),
         },
       );
+
       expect(response.status).toBe(400);
+
       const responseBody = await response.json();
+
       expect(responseBody).toEqual({
         name: "ValidationError",
         message: "O email informado já está sendo utilizado.",
@@ -116,150 +95,131 @@ describe("PATCH /api/v1/users/[username]", () => {
         status_code: 400,
       });
     });
-  });
 
-  test("With unique 'email'", async () => {
-    const user1Response = await fetch("http://localhost:3000/api/v1/users", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        username: "uniqueUser1",
-        email: "uniqueUser1@eduarte.dev",
-        password: "senha123",
-      }),
-    });
-    expect(user1Response.status).toBe(201);
+    test("With unique 'username'", async () => {
+      const createdUser = await orchestrator.createUser();
 
-    const response = await fetch(
-      "http://localhost:3000/api/v1/users/uniqueUser1",
-      {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
+      const response = await fetch(
+        `http://localhost:3000/api/v1/users/${createdUser.username}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            username: "uniqueUser2",
+          }),
         },
-        body: JSON.stringify({
-          username: "uniqueUser2",
-        }),
-      },
-    );
-    expect(response.status).toBe(200);
-    const responseBody = await response.json();
-    expect(responseBody).toEqual({
-      id: responseBody.id,
-      username: "uniqueUser2",
-      email: "uniqueUser1@eduarte.dev",
-      password: responseBody.password,
-      created_at: responseBody.created_at,
-      updated_at: responseBody.updated_at,
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        username: "uniqueUser2",
+        email: createdUser.email,
+        password: responseBody.password,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      expect(responseBody.updated_at > responseBody.created_at).toBe(true);
     });
 
-    expect(uuidVersion(responseBody.id)).toBe(4);
-    expect(Date.parse(responseBody.created_at)).not.toBeNaN();
-    expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+    test("With unique 'email'", async () => {
+      const createdUser = await orchestrator.createUser();
 
-    expect(responseBody.updated_at > responseBody.created_at).toBe(true);
-  });
-  test("With unique 'username'", async () => {
-    const user1Response = await fetch("http://localhost:3000/api/v1/users", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        username: "uniqueEmail1",
-        email: "uniqueEmail1@eduarte.dev",
-        password: "senha123",
-      }),
-    });
-    expect(user1Response.status).toBe(201);
+      const response = await fetch(
+        `http://localhost:3000/api/v1/users/${createdUser.username}`,
 
-    const response = await fetch(
-      "http://localhost:3000/api/v1/users/uniqueEmail1",
-      {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            email: "uniqueEmail2@eduarte.dev",
+          }),
         },
-        body: JSON.stringify({
-          email: "uniqueEmail2@eduarte.dev",
-        }),
-      },
-    );
-    expect(response.status).toBe(200);
-    const responseBody = await response.json();
-    expect(responseBody).toEqual({
-      id: responseBody.id,
-      username: "uniqueEmail1",
-      email: "uniqueEmail2@eduarte.dev",
-      password: responseBody.password,
-      created_at: responseBody.created_at,
-      updated_at: responseBody.updated_at,
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        username: createdUser.username,
+        email: "uniqueEmail2@eduarte.dev",
+        password: responseBody.password,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      expect(responseBody.updated_at > responseBody.created_at).toBe(true);
     });
 
-    expect(uuidVersion(responseBody.id)).toBe(4);
-    expect(Date.parse(responseBody.created_at)).not.toBeNaN();
-    expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
-
-    expect(responseBody.updated_at > responseBody.created_at).toBe(true);
-  });
-
-  test("With new 'password'", async () => {
-    const user1Response = await fetch("http://localhost:3000/api/v1/users", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        username: "newPassword1",
-        email: "newPassword1@eduarte.dev",
+    test("With new 'password'", async () => {
+      const createdUser = await orchestrator.createUser({
         password: "newPassword1",
-      }),
-    });
-    expect(user1Response.status).toBe(201);
+      });
 
-    const response = await fetch(
-      "http://localhost:3000/api/v1/users/newPassword1",
-      {
-        method: "PATCH",
-        headers: {
-          "Content-Type": "application/json",
+      const response = await fetch(
+        `http://localhost:3000/api/v1/users/${createdUser.username}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            password: "newPassword2",
+          }),
         },
-        body: JSON.stringify({
-          password: "newPassword2",
-        }),
-      },
-    );
-    expect(response.status).toBe(200);
-    const responseBody = await response.json();
-    expect(responseBody).toEqual({
-      id: responseBody.id,
-      username: "newPassword1",
-      email: "newPassword1@eduarte.dev",
-      password: responseBody.password,
-      created_at: responseBody.created_at,
-      updated_at: responseBody.updated_at,
+      );
+
+      expect(response.status).toBe(200);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        username: createdUser.username,
+        email: createdUser.email,
+        password: responseBody.password,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+
+      expect(responseBody.updated_at > responseBody.created_at).toBe(true);
+
+      const userInDatabase = await user.findOneByUsername(createdUser.username);
+      const correctPasswordMatch = await password.compare(
+        "newPassword2",
+        userInDatabase.password,
+      );
+
+      const incorrectPasswordMatch = await password.compare(
+        "newPassword1",
+        userInDatabase.password,
+      );
+
+      expect(correctPasswordMatch).toBe(true);
+      expect(incorrectPasswordMatch).toBe(false);
     });
-
-    expect(uuidVersion(responseBody.id)).toBe(4);
-    expect(Date.parse(responseBody.created_at)).not.toBeNaN();
-    expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
-
-    expect(responseBody.updated_at > responseBody.created_at).toBe(true);
-
-    const userInDatabase = await user.findOneByUsername("newPassword1");
-    const correctPasswordMatch = await password.compare(
-      "newPassword2",
-      userInDatabase.password,
-    );
-
-    const incorrectPasswordMatch = await password.compare(
-      "newPassword1",
-      userInDatabase.password,
-    );
-
-    expect(correctPasswordMatch).toBe(true);
-    expect(incorrectPasswordMatch).toBe(false);
   });
 });
+         

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,6 +1,9 @@
 import retry from "async-retry";
+import { faker } from "@faker-js/faker";
+
 import database from "infra/database.js";
 import migrator from "models/migrator.js";
+import user from "models/user.js";
 
 async function waitForAllServices() {
   await waitForWebServer();
@@ -29,10 +32,20 @@ async function runPendingMigrations() {
   await migrator.runPendingMigrations();
 }
 
+async function createUser(userObject) {
+  return await user.create({
+    username:
+      userObject?.username || faker.internet.username().replace(/[_.-]/g, ""),
+    email: userObject?.email || faker.internet.email(),
+    password: userObject?.password || "validpassword",
+  });
+}
+
 const orchestrator = {
   waitForAllServices,
   clearDatabase,
   runPendingMigrations,
+  createUser,
 };
 
 export default orchestrator;


### PR DESCRIPTION
## Descrição

Implementa função `createUser` no orchestrator para centralizar a criação de usuários nos testes.

## Mudanças

- ✨ Adiciona função `createUser` ao orchestrator
- ♻️ Refatora testes de usuários para usar `orchestrator.createUser`
- 📦 Atualiza dependências no package.json

## Testes

- ✅ Todos os testes de integração passando
- ✅ Testes de GET /api/v1/users/[username] atualizados
- ✅ Testes de PATCH /api/v1/users/[username] atualizados